### PR TITLE
styles: set max height of the page

### DIFF
--- a/entrypoints/injected/App.tsx
+++ b/entrypoints/injected/App.tsx
@@ -46,7 +46,7 @@ export default () => {
 
   return (
     <div
-      className={`fixed overflow-hidden text-xs text-#000 bg-popover rounded border-1 border-#e5e5e5 border-solid shadow-md z-10 antialiased h-auto transition-width !font-['Inter'] js-fullscreen-prevent-event-capture ${minimized ? 'w-50' : 'w-80'}`}
+      className={`fixed text-xs text-#000 bg-popover rounded border-1 border-#e5e5e5 border-solid shadow-md z-10 antialiased h-auto transition-width !font-['Inter'] js-fullscreen-prevent-event-capture ${minimized ? 'w-50' : 'w-80'} max-h-[calc(100vh-50px)] overflow-y-scroll scrollbar-hide`}
       style={{
         left: position[0],
         top: position[1],

--- a/entrypoints/injected/components/Code.tsx
+++ b/entrypoints/injected/components/Code.tsx
@@ -137,7 +137,7 @@ export const CodeArea = memo((props: { minimized?: boolean }) => {
     <>
       {!name && !props.minimized && <div className="p-4 font-600 text-13px">Select Layer </div>}
       <div className={`relative ${props.minimized || !name ? 'hidden' : ''}`}>
-        <div className="flex px-4 py-2 items-center border-b border-#e5e5e5 border-solid font-600 text-13px">
+        <div className="flex px-4 py-2 items-center border-b border-#e5e5e5 border-solid font-600 text-13px sticky top-45px bg-#fff z-2">
           <span className="p-1 hover:bg-#e5e5e5/50 rounded-sm cursor-pointer truncate" onClick={handleCopy(name)}>
             {name}
           </span>

--- a/entrypoints/injected/components/Header.tsx
+++ b/entrypoints/injected/components/Header.tsx
@@ -43,7 +43,7 @@ const Header = forwardRef(function (
       onMouseDown={onMouseDown}
       onMouseUp={onMouseUp}
       ref={ref}
-      className={`flex items-center gap-2 border-b border-#e5e5e5 border-solid cursor-grab active:cursor-grabbing transition-padding ${minimized ? 'py-2.5 px-3' : 'py-3 px-4'}`}
+      className={`flex items-center gap-2 border-b border-#e5e5e5 border-solid cursor-grab active:cursor-grabbing transition-padding ${minimized ? 'py-2.5 px-3' : 'py-3 px-4'} sticky top-0 bg-#fff z-2`}
     >
       {engine === 'unocss' ? (
         <img src={Logo} className="w-5 h-5 rounded cursor-pointer" onClick={() => setEngine('tailwind')} />


### PR DESCRIPTION
 没有限制整个插件的高度，当内容过多需要拖动才行。
 加了最大宽度，当内容溢出时添加隐形滚动条
 (100vh - 50px) 50的由来是 figma上面toolbar height 48px 我取整了一下

translate from GPT

No restriction on the overall height of the plugin; dragging is required when there is excessive content. 
Added a maximum width and invisible scrollbar when content overflows. 
The origin of '50' in (100vh - 50px) is because the toolbar height on Figma is 48px; I rounded it up.