### PR TITLE
Fix/setting menu drag

### DIFF
--- a/entrypoints/injected/components/Code.tsx
+++ b/entrypoints/injected/components/Code.tsx
@@ -152,7 +152,7 @@ export const CodeArea = memo((props: { minimized?: boolean }) => {
             <>
               {!(index % 2) ? (
                 <div
-                  className="flex-center"
+                  className="flex-center cursor-pointer"
                   onClick={() => (index === 0 ? setAtomicExpand(!atomicExpand) : setExpand(!expand))}
                 >
                   <span className="text-#000/30 text-11px">{u.type}</span>

--- a/entrypoints/injected/components/Header.tsx
+++ b/entrypoints/injected/components/Header.tsx
@@ -76,7 +76,12 @@ const Header = forwardRef(function (
         ></span>
       )}
       <span className="flex-1 font-700 text-sm">Fubukicss Tool</span>
-      <div className="p-.5 flex-center rounded bg-#eee">
+      <div
+        className="p-.5 flex-center rounded bg-#eee"
+        onMouseDown={(e) => {
+          e.stopPropagation()
+        }}
+      >
         {!minimized && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>


### PR DESCRIPTION
修复问题：鼠标 Settings 下拉菜单后，会拖动插件的主面板，且会导致鼠标无法释放