### PR TITLE
fix: deep select for windows

### DIFF
--- a/entrypoints/injected/components/Code.tsx
+++ b/entrypoints/injected/components/Code.tsx
@@ -1,6 +1,6 @@
 import { ChevronDownIcon, DividerHorizontalIcon } from '@radix-ui/react-icons'
 import { useAtom, useAtomValue } from 'jotai'
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Fragment, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Clipboard } from 'react-feather'
 import { toTailwindcss } from 'transform-to-tailwindcss-core'
 import { toUnocssClass } from 'transform-to-unocss-core'
@@ -149,7 +149,7 @@ export const CodeArea = memo((props: { minimized?: boolean }) => {
           onClick={(e) => e.stopPropagation()}
         >
           {unoResult?.map((u, index) => (
-            <>
+            <Fragment key={u.title}>
               {!(index % 2) ? (
                 <div
                   className="flex-center cursor-pointer"
@@ -174,7 +174,6 @@ export const CodeArea = memo((props: { minimized?: boolean }) => {
                 ></span>
               )}
               <div
-                key={u.title}
                 className={cn(
                   'flex flex-col items-stretch bg-#f5f5f5 rounded-sm overflow-hidden',
                   u.type === 'css' && !expand ? '!hidden' : '',
@@ -215,7 +214,7 @@ export const CodeArea = memo((props: { minimized?: boolean }) => {
                   </>
                 )}
               </div>
-            </>
+            </Fragment>
           ))}
         </div>
       </div>

--- a/entrypoints/injected/components/Header.tsx
+++ b/entrypoints/injected/components/Header.tsx
@@ -59,7 +59,14 @@ const Header = forwardRef(function (
       canvas?.removeEventListener('wheel', wheelHandler, false)
     }
   }, [altPressing, metaPressing])
-
+  // The DropdownMenuTrigger has been disabled from opening the menu when holding down the Ctrl key
+  // https://github.com/radix-ui/primitives/blob/main/packages/react/dropdown-menu/src/DropdownMenu.tsx#L119
+  const onMouseEnter = function () {
+    toggleMetaPress(false)
+  }
+  const onMouseLeave = function () {
+    toggleMetaPress(metaPressing)
+  }
   return (
     <header
       onMouseDown={onMouseDown}
@@ -85,7 +92,11 @@ const Header = forwardRef(function (
         {!minimized && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Settings size={16} className="mr-1.5 text-#000/50 hover:text-#000 cursor-pointer" />
+              <Settings
+                onMouseEnter={onMouseEnter}
+                onMouseLeave={onMouseLeave}
+                size={16}
+                className="mr-1.5 text-#000/50 hover:text-#000 cursor-pointer" />
             </DropdownMenuTrigger>
             <DropdownMenuContent className="w-56 z-1001 border-1 border-solid border-muted">
               <DropdownMenuLabel className="cursor-default">Settings</DropdownMenuLabel>

--- a/entrypoints/injected/components/Header.tsx
+++ b/entrypoints/injected/components/Header.tsx
@@ -1,6 +1,6 @@
 import { CheckIcon } from '@radix-ui/react-icons'
 import { useAtom } from 'jotai'
-import { ForwardedRef, forwardRef, memo, MouseEvent, useEffect } from 'react'
+import { ForwardedRef, forwardRef, memo, MouseEvent, useEffect, useCallback } from 'react'
 import { Maximize2, Minimize2, Settings } from 'react-feather'
 
 import Logo from '@/entrypoints/assets/fubukicss.svg'
@@ -61,12 +61,12 @@ const Header = forwardRef(function (
   }, [altPressing, metaPressing])
   // The DropdownMenuTrigger has been disabled from opening the menu when holding down the Ctrl key
   // https://github.com/radix-ui/primitives/blob/main/packages/react/dropdown-menu/src/DropdownMenu.tsx#L119
-  const onMouseEnter = function () {
+  const onMouseEnter = useCallback(() => {
     toggleMetaPress(false)
-  }
-  const onMouseLeave = function () {
+  }, [])
+  const onMouseLeave = useCallback(() => {
     toggleMetaPress(metaPressing)
-  }
+  }, [metaPressing])
   return (
     <header
       onMouseDown={onMouseDown}

--- a/entrypoints/utils/key.ts
+++ b/entrypoints/utils/key.ts
@@ -1,4 +1,6 @@
-const originalMetaKeyGetter = Object.getOwnPropertyDescriptor(MouseEvent.prototype, 'metaKey')!
+const isMac = /mac/i.test(navigator.platform)
+const metaKey = isMac ? 'metaKey' : 'ctrlKey'
+const originalMetaKeyGetter = Object.getOwnPropertyDescriptor(MouseEvent.prototype, metaKey)!
 const originalAltKeyGetter = Object.getOwnPropertyDescriptor(MouseEvent.prototype, 'altKey')!
 
 export function toggleAltPress(press: boolean) {
@@ -15,12 +17,12 @@ export function toggleAltPress(press: boolean) {
 
 export function toggleMetaPress(press: boolean) {
   if (press) {
-    Object.defineProperty(MouseEvent.prototype, 'metaKey', {
+    Object.defineProperty(MouseEvent.prototype, metaKey, {
       get() {
         return true
       },
     })
   } else {
-    Object.defineProperty(MouseEvent.prototype, 'metaKey', originalMetaKeyGetter)
+    Object.defineProperty(MouseEvent.prototype, metaKey, originalMetaKeyGetter)
   }
 }


### PR DESCRIPTION
Deep select will not work on Windows; the metaKey needs to be changed to ctrlKey on Windows